### PR TITLE
python3 shebang

### DIFF
--- a/auto-smart-commit.py
+++ b/auto-smart-commit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import re
 import sys


### PR DESCRIPTION
Change shebang to python3, as aliases does not work and syntax of documenting requires python3